### PR TITLE
RGB sensor color correction

### DIFF
--- a/src/TroykaColorSensor.cpp
+++ b/src/TroykaColorSensor.cpp
@@ -14,12 +14,17 @@ void TroykaColorSensor::colorRead(uint8_t* r, uint8_t* g, uint8_t* b) {
     uint16_t red, green, blue, baseLevel;
     getRawData(&red, &green, &blue, &baseLevel);
 
-    *r = (uint8_t)(256L * red / baseLevel);
+    float redFixed = (float)red;
     // float constants is inversely proportional to the sensitivity of
-    // color component sensors (reduced to red). You can get it from 
+    // color component sensors (reduced to red). You can get it from
     // datasheet (figure 2, page 6): https://cdn-shop.adafruit.com/datasheets/TCS34725.pdf
-    *g = (uint8_t)(1.354 * 256L * green / baseLevel);
-    *b = (uint8_t)(1.571 * 256L * blue / baseLevel);
+    float greenFixed = (float)green * 1.354;
+    float blueFixed = (float)blue * 1.571;
+
+    float max = (redFixed > greenFixed && redFixed > blueFixed) ? redFixed : (greenFixed > blueFixed) ? greenFixed : blueFixed;
+    *r = (uint8_t)(255 * redFixed / max);
+    *g = (uint8_t)(255 * greenFixed / max);
+    *b = (uint8_t)(255 * blueFixed / max);
 }
 
 RGB TroykaColorSensor::colorRead(void) {

--- a/src/TroykaColorSensor.cpp
+++ b/src/TroykaColorSensor.cpp
@@ -21,10 +21,10 @@ void TroykaColorSensor::colorRead(uint8_t* r, uint8_t* g, uint8_t* b) {
     float greenFixed = (float)green * 1.354;
     float blueFixed = (float)blue * 1.571;
 
-    float max = (redFixed > greenFixed && redFixed > blueFixed) ? redFixed : (greenFixed > blueFixed) ? greenFixed : blueFixed;
-    *r = (uint8_t)(255 * redFixed / max);
-    *g = (uint8_t)(255 * greenFixed / max);
-    *b = (uint8_t)(255 * blueFixed / max);
+    float maxFixed = max(redFixed,max(greenFixed, blueFixed));
+    *r = (uint8_t)(255 * redFixed / maxFixed);
+    *g = (uint8_t)(255 * greenFixed / maxFixed);
+    *b = (uint8_t)(255 * blueFixed / maxFixed);
 }
 
 RGB TroykaColorSensor::colorRead(void) {

--- a/src/TroykaColorSensor.cpp
+++ b/src/TroykaColorSensor.cpp
@@ -2,7 +2,7 @@
  * This file is a part of Troyka modules library.
  *
  * Implement: Troyka color sensor module library. Uses Adafruit_TCS34725 library.
- * © Amperka LLC (https://amperka.com, dev@amperka.com)
+ * Â© Amperka LLC (https://amperka.com, dev@amperka.com)
  * 
  * Author: Yury Botov <by@amperka.ru>
  * License: GPLv3, all text here must be included in any redistribution.
@@ -15,8 +15,11 @@ void TroykaColorSensor::colorRead(uint8_t* r, uint8_t* g, uint8_t* b) {
     getRawData(&red, &green, &blue, &baseLevel);
 
     *r = (uint8_t)(256L * red / baseLevel);
-    *g = (uint8_t)(256L * green / baseLevel);
-    *b = (uint8_t)(256L * blue / baseLevel);
+    // float constants is inversely proportional to the sensitivity of
+    // color component sensors (reduced to red). You can get it from 
+    // datasheet (figure 2, page 6): https://cdn-shop.adafruit.com/datasheets/TCS34725.pdf
+    *g = (uint8_t)(1.354 * 256L * green / baseLevel);
+    *b = (uint8_t)(1.571 * 256L * blue / baseLevel);
 }
 
 RGB TroykaColorSensor::colorRead(void) {

--- a/src/TroykaColorSensor.h
+++ b/src/TroykaColorSensor.h
@@ -2,7 +2,7 @@
  * This file is a part of Troyka modules library.
  *
  * Defines: Troyka color sensor module library. Uses Adafruit_TCS34725 library.
- * © Amperka LLC (https://amperka.com, dev@amperka.com)
+ * Â© Amperka LLC (https://amperka.com, dev@amperka.com)
  * 
  * Author: Yury Botov <by@amperka.ru>
  * License: GPLv3, all text here must be included in any redistribution.


### PR DESCRIPTION
RGB sensor color correction .Эксперименты с платами датчика  показали, что он нередко врет, и особенно "зеленый-> красный". Из pdf следует, что чувствительность датчиков компонентов разная. Адафрут в библиотеке не отработали эту коррекцию. Поэтому ее добавляю я. Коэффициенты приведены к уровню чувствительности красного (он самый большой) После этой коррекции вероятность ошибки определения цвета значительно снижается - проверено. 